### PR TITLE
Fix tomcat download which causes build to fail

### DIFF
--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -17,14 +17,30 @@ ENV LC_ALL en_AU.UTF-8
 # Fix sh
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
+ENV TOMCAT_MAJOR 7
+ENV TOMCAT_VERSION 7.0.82
 # Get Tomcat
-RUN wget --quiet --no-cookies http://apache.mirror.digitalpacific.com.au/tomcat/tomcat-7/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz -O /tmp/tomcat.tgz && \
-tar xzvf /tmp/tomcat.tgz -C /opt && \
-mv /opt/apache-tomcat-${TOMCAT_VERSION} /opt/tomcat && \
-rm /tmp/tomcat.tgz && \
-rm -rf /opt/tomcat/webapps/examples && \
-rm -rf /opt/tomcat/webapps/docs
-#rm -rf /opt/tomcat/webapps/ROOT
+ENV TOMCAT_TGZ_URLS \
+    https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz \
+    # if the version is outdated, we might have to pull from the dist/archive :/
+    https://www-us.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz \
+    https://www.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz \
+    https://archive.apache.org/dist/tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz
+
+RUN set -eux; \
+        \
+        success=; \
+        for url in $TOMCAT_TGZ_URLS; do \
+                if wget -O /tmp/tomcat.tgz "$url"; then \
+                        success=1; \
+                        break; \
+                fi; \
+        done; \
+        [ -n "$success" ]; \
+        tar xzvf /tmp/tomcat.tgz -C /opt && \
+        mv /opt/apache-tomcat-${TOMCAT_VERSION} /opt/tomcat && \
+        rm /tmp/tomcat.tgz && \
+        rm -rf /opt/tomcat/webapps/*
 
 # Add admin/admin user
 ADD tomcat-users.xml /opt/tomcat/conf/


### PR DESCRIPTION
The build on master currently fails, and this change fixes it.

This is mostly taken from @rsingh5's [comment](https://github.com/NrgXnat/xnat-docker-compose/issues/3#issuecomment-336905001) on #3. And I believe his comment came essentially from the approach taken in tomcat's Dockerfiles (see, for example, the [tomcat:jre7-alpine Dockerfile](https://github.com/docker-library/tomcat/blob/master/7/jre7-alpine/Dockerfile#L26)).