### PR TITLE
updates to README with some testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains files to bootstrap XNAT deployment. The build creates f
 
 ## Usage
 
+
 1. Clone the [xnat-docker-compose](https://github.com/NrgXnat/xnat-docker-compose) repository.
 2. Configurations: The default configuration is sufficient to run the deployment. The following files can be modified if you want to change the default configuration
 
@@ -25,18 +26,51 @@ This repository contains files to bootstrap XNAT deployment. The build creates f
     - **postgres/XNAT.sql**: Database configuration. Mainly used to customize the database user or password. See [Configuring PostgreSQL for XNAT](https://wiki.xnat.org/documentation/getting-started-with-xnat-1-7/installing-xnat-1-7/configuring-postgresql-for-xnat).
     - **tomcat/Dockerfile**: Builds the tomcat image, into which the XNAT war will be deployed.
     - **tomcat/setenv.sh**: Tomcat's launch arguments, set through the `JAVA_OPTS` environment variable.
-    - **tomcat/tomcat-users.xml**: [Tomcat manager](https://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html) settings.
+    - **tomcat/tomcat-users.xml**: [Tomcat manager](https://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html) settings. It is highly recommended to change the login from "admin" with password "admin" to the server if it is going live.
     - **tomcat/xnat-conf.properties**: XNAT database configuration properties. There is a default version
     - **prometheus/prometheus.yaml**: Prometheus configuration
 
-3. Start the system
 
-        $ cd containerized-xnat
-        $ docker-compose up -d
+3. Download [latest XNAT WAR](https://bintray.com/nrgxnat/applications/XNAT/_latestVersion)
 
-4. Download [latest XNAT WAR](https://bintray.com/nrgxnat/applications/XNAT/_latestVersion)
+```
+wget --quiet --no-cookies https://bintray.com/nrgxnat/applications/download_file?file_path=xnat-web-1.7.4.war -O webapps/xnat.war
+```
 
-        wget --quiet --no-cookies https://bintray.com/nrgxnat/applications/download_file?file_path=xnat-web-1.7.4.war -O webapps/xnat.war
+4. Start the system
+
+```
+$ cd xnat-docker-compose
+$ docker-compose up -d
+```
+
+Note that at this point, if you go to `localhost/xnat` you won't see a working web application. It takes upwards of a minute
+to initialize the database, and you can follow progress by reading the docker compose log of the server:
+
+```
+docker-compose logs -f --tail=20 xnat-web 
+Attaching to xnatdockercompose_xnat-web_1
+xnat-web_1    | INFO: Starting Servlet Engine: Apache Tomcat/7.0.82
+xnat-web_1    | Oct 24, 2017 3:17:02 PM org.apache.catalina.startup.HostConfig deployWAR
+xnat-web_1    | INFO: Deploying web application archive /opt/tomcat/webapps/xnat.war
+xnat-web_1    | Oct 24, 2017 3:17:14 PM org.apache.catalina.startup.TldConfig execute
+xnat-web_1    | INFO: At least one JAR was scanned for TLDs yet contained no TLDs. Enable debug logging for this logger for a complete list of JARs that were scanned but no TLDs were found in them. Skipping unneeded JARs during scanning can improve startup time and JSP compilation time.
+xnat-web_1    | SOURCE: /opt/tomcat/webapps/xnat/
+xnat-web_1    | ===========================
+xnat-web_1    | New Database -- BEGINNING Initialization
+xnat-web_1    | ===========================
+xnat-web_1    | ===========================
+xnat-web_1    | Database initialization complete.
+xnat-web_1    | ===========================
+xnat-web_1    | Oct 24, 2017 3:18:27 PM org.apache.catalina.startup.HostConfig deployWAR
+xnat-web_1    | INFO: Deployment of web application archive /opt/tomcat/webapps/xnat.war has finished in 84,717 ms
+xnat-web_1    | Oct 24, 2017 3:18:27 PM org.apache.coyote.AbstractProtocol start
+xnat-web_1    | INFO: Starting ProtocolHandler ["http-bio-8080"]
+xnat-web_1    | Oct 24, 2017 3:18:27 PM org.apache.coyote.AbstractProtocol start
+xnat-web_1    | INFO: Starting ProtocolHandler ["ajp-bio-8009"]
+xnat-web_1    | Oct 24, 2017 3:18:27 PM org.apache.catalina.startup.Catalina start
+xnat-web_1    | INFO: Server startup in 84925 ms
+```
 
 Your XNAT will soon be available at http://localhost/xnat.
 
@@ -44,27 +78,63 @@ Your XNAT will soon be available at http://localhost/xnat.
 ## Troubleshooting
 
 
-- Get a shell in a running container:
+### Get a shell in a running container
+To list all containers and to get container id run
 
-     To list all containers and to get container id run
+```
+docker ps
+```
 
-     `docker ps`
+You can also grab the name and put it into ane environment variable:
 
-     To get into a running container
 
-      `docker exec -it <container ID> bash`
+```
+$ NAME=$(docker ps -aqf "name=xnatdockercompose_xnat-web")
+$ echo $NAME
+42d07bc7710b
+```
 
-- Read Tomcat logs:
+To get into a running container
 
-     `docker exec -it <container id  for xnatdocker_xnat-web_1 >  tail -f  /opt/tomcat/logs/catalina.2017-07-28.log `
+```
+docker exec -it <container ID> bash
+docker exec -it $NAME bash
+```
 
-- Bring all the instances down by running
+### Read Tomcat logs
 
-     `docker-compose down --rmi all`  (this will bring down all container and remove all the images)
+List available logs
 
-- Bring XNAT instance up again
+```
+$ docker exec -it $NAME ls  /opt/tomcat/logs/
 
-     `docker-compose up -d `
+catalina.2017-10-24.log      localhost_access_log.2017-10-24.txt
+host-manager.2017-10-24.log  manager.2017-10-24.log
+localhost.2017-10-24.log
+```
+
+View a particular log
+
+```
+docker exec -it $NAME  >  tail -f  /opt/tomcat/logs/catalina.2017-07-24.log
+```
+
+### Controlling Instances
+
+#### Stop Instances
+Bring all the instances down (this will bring down all container and remove all the images) by running
+
+```
+docker-compose down --rmi all 
+```
+
+#### Bring up instances
+This will bring all instances up again. The `-d` means "detached" so you won't see any output to the terminal.
+
+```
+docker-compose up -d
+```
+
 
 ## Monitoring
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ host-manager.2017-10-24.log  manager.2017-10-24.log
 localhost.2017-10-24.log
 ```
 
-View a particular log
+View a particular log, if you don't want to use docker-compose.
+
 
 ```
-docker exec -it $NAME  >  tail -f  /opt/tomcat/logs/catalina.2017-07-24.log
+docker exec -it $NAME cat /opt/tomcat/logs/catalina.2017-10-24.log
 ```
 
 ### Controlling Instances


### PR DESCRIPTION
hey @nrgxnat-bot @johnflavin and team! The work you did this past week looks great! I got it up and running very quickly, and only did some slight reorganization to get it working proper (once the docker images are started, the user doesn't have permission to download into the webapps directory, so either they could get `xnat.war` before or shell into the container and get it from within - I opted for the first because it seemed more logical.

I don't have significant changes, just slight tweaks to the README in terms of instructions. What I can do next is deploy a dummy version on Google Cloud for a researcher, and then as we get feedback / requests we can chat about features. Hopefully this repo has enough insight into how things are working so that I could contribute more than just posting issues, haha.

Take a look at the slight tweaks and let me know your thoughts. As I set up a production version of this I'm going to create more specific instructions to live alongside the docker compose image. They won't replace but will support the robust docs you guys already have.

I've never tried out cAdvisor before... my goodness, he's adorable. 

![image](https://user-images.githubusercontent.com/814322/31952553-bc8d0042-b895-11e7-8774-1b815fa65a57.png)
