### PR TITLE
fix invalid bash syntax

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -7,7 +7,7 @@ FROM postgres:12.2-alpine
 # $ docker-compose up --detach
 #
 
-RUN if [ ! -z ${POSTGRES_GID} && ${POSTGRES_GID} != 70 ]; then \
+RUN if [ x${POSTGRES_GID} != x70  ]; then \
         sed -i'' -E 's/postgres:x:70:postgres/postgres:x:'${POSTGRES_GID}':postgres/' /etc/group; \
         sed -i'' -E 's/postgres:x:70:70:/postgres:x:'${POSTGRES_UID}':'${POSTGRES_GID}':/' /etc/passwd; \
     fi;


### PR DESCRIPTION
Fixes #53  :

&& is not valid in single brackets
the -z to check first doesn't actually work because both sides are evaluated regardless