### PR TITLE
Turned off autocrlf for .sh and .conf files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+*.sh text eol=lf
+*.conf text eol=lf
+


### PR DESCRIPTION
A proposition to simplify the getting-started process on Windows, especially for not very tech or git people.
Configures the repository itself to preserve LF as EOL for `.sh` and `.conf` files on any platform during the checkout.
Should fix #42.