### PR TITLE
Bump gradle version for M1 mac

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I'm using `osx-arm64` and was finding errors like this where I couldn't get a TCP connection
![image](https://user-images.githubusercontent.com/15052188/140783592-f0ab4503-d530-4ada-942f-45b86cb0f56c.png)

Looks like `gradle` have Apple silicon native support as of `6.9` https://docs.gradle.org/6.9/release-notes.html#native-support-for-apple-silicon

I have simply run `./gradlew wrapper --gradle-version=6.9` and I am now able to launch an XNAT server
