### PR TITLE
clarify ec2-user in migration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ sudo chown -R ec2-user:ec2-user xnat-data
 sudo chown -R ec2-user:ec2-user xnat/plugins
 ```
 
+Where `ec2-user` is the system user account that tomcat will use to manage your XNAT data. This user should correspond to `TOMCAT_UID` and `TOMCAT_GID`,
+and likely `NB_UID` and `NB_GID` discussed below.
+
 Next checkout the `features/jupyterhub` branch
 ```
 git checkout -b features/jupyterhub origin/features/jupyterhub


### PR DESCRIPTION
clarify what `ec2-user` means in the migration section of the documentation.

It might also be worthwhile to offer a suggestion for users migrating, e.g. suggest creating a user `xnat` to manage the XNAT data.